### PR TITLE
Don't lock executable location at load time

### DIFF
--- a/uiua-mode.el
+++ b/uiua-mode.el
@@ -26,8 +26,7 @@
   :group 'uiua)
 
 (defcustom uiua-command
-  (cond ((executable-find "uiua") "uiua")
-	(t "/usr/bin/uiua"))
+  "uiua"
   "Default command to use Uiua."
   :group 'uiua-mode
   :version "27.1"


### PR DESCRIPTION
If a full path to the executable is frozen at load time, then setting exec-path later will confusingly fail to help the mode find the executable. This also prevents directory-local path mechanisms like direnv from working correctly.

A better default here is to use the unqualified executable name, and then the user can customise this to a full path if they need to.