### PR TITLE
Various packaging tweaks

### DIFF
--- a/uiua-mode.el
+++ b/uiua-mode.el
@@ -3,7 +3,7 @@
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; URL: https://github.com/crmsnbleyd/uiua-mode
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "27.1") (reformatter "0.7"))
 ;; Keywords: languages, uiua
 
 ;;; Commentary:
@@ -13,6 +13,7 @@
 ;;; Code:
 (require 'face-remap)
 (require 'seq)
+(require 'reformatter)
 (eval-when-compile (require 'rx))
 
 (defgroup uiua nil
@@ -268,88 +269,24 @@ If GLYPHS is nil, only the latter behaviour is displayed."
     table)
   "Syntax table for `uiua-mode'.")
 
-(defun uiua--buffer-apply-command (cmd &optional args)
-  "Execute shell command CMD with ARGS and current buffer as input and output.
-Use buffer as input and replace the whole buffer with the
-output.  If CMD fails the buffer remains unchanged."
-  (set-buffer-modified-p t)
-  (let* ((out-file (make-temp-file "uiua-output"))
-	 (err-file (make-temp-file "uiua-error"))
-	 (coding-system-for-read 'utf-8)
-	 (coding-system-for-write 'utf-8))
-    (unwind-protect
-	(let ((curr-file (buffer-file-name))
-	      (curr-bufname (buffer-name))
-	      (message-log-max nil))
-	  (set-visited-file-name out-file)
-	  (with-temp-message "" (save-buffer))
-	  (set-visited-file-name curr-file)
-	  (rename-buffer curr-bufname))
-	(let* ((_errcode
-		(apply 'call-process cmd nil
-		       `(,(get-buffer-create "*uiua-output*") ,err-file)
-		       nil
-		       (append args (list out-file))))
-	       (err-file-empty-p
-		(equal 0 (nth 7 (file-attributes err-file))))
-	       (out-file-empty-p
-		(equal 0 (nth 7 (file-attributes out-file)))))
-	  (if err-file-empty-p
-	      (if out-file-empty-p
-		  (message "Error: %s produced no output and no errors, buffer is unchanged" cmd)
-		;; Command successful, insert file with replacement to preserve
-		;; markers.
-		(insert-file-contents out-file nil nil nil t))
-	    (progn
-	      ;; non-null stderr, command must have failed
-	      (with-current-buffer
-		  (get-buffer-create "*uiua-mode*")
-		(insert-file-contents err-file)
-		(buffer-string))
-	      (message "Error: %s ended with errors, leaving buffer alone, see *uiua-mode* buffer for stderr" cmd)
-	      (with-temp-buffer
-		(insert-file-contents err-file)
-		;; use (warning-minimum-level :debug) to see this
-		(display-warning cmd
-				 (buffer-substring-no-properties (point-min) (point-max))
-				 :debug)))))
-      (ignore-errors
-	(delete-file err-file))
-      (ignore-errors
-	(delete-file out-file)))))
-
-(defun uiua-process-load-file ()
-  "Load the file currently open in buffer."
-  (interactive))
-
-(defun uiua-format-buffer ()
-  "Format buffer using the in-built formatter."
-  (interactive)
-  (let ((original-text-scale (if text-scale-mode text-scale-mode-amount 0)))
-    (when (called-interactively-p "interactive")
-      (unless uiua-command
-	(error "Uiua binary not found, please set `uiua-command'"))
-      (message "Autoformatting code with %s fmt."
-	       uiua-command))
-    (uiua--buffer-apply-command uiua-command (list "fmt"))
-    (text-scale-set original-text-scale)))
-
-(defun uiua--replace-region (beg end replacement)
-  "Replace text in BUFFER in region (BEG END) with REPLACEMENT."
-    (save-excursion
-      (goto-char (point-min))
-      (insert replacement)
-      (delete-region beg end)))
+;;;###autoload (autoload 'uiua-format-buffer "uiua-mode" nil t)
+;;;###autoload (autoload 'uiua-format-on-save-mode "uiua-mode" nil t)
+(reformatter-define uiua-format
+  :program uiua-command
+  :args (list "fmt")
+  :stdin nil
+  :stdout nil
+  :input-file (reformatter-temp-file-in-current-directory)
+  :lighter " UiuaFmt")
 
 ;;;###autoload
 (define-derived-mode uiua-base-mode prog-mode "Uiua"
   "Generic Major mode for editing Uiua files."
   :syntax-table uiua--syntax-table
-  (add-hook
-   'before-save-hook
-   'uiua-format-buffer nil t)
   (setq-local comment-start "#")
   (setq-local comment-start-skip "#+\\s-*"))
+
+(add-hook 'uiua-base-mode-hook 'uiua-format-on-save-mode)
 
 ;;;###autoload
 (define-derived-mode uiua-mode uiua-base-mode "Uiua"

--- a/uiua-mode.el
+++ b/uiua-mode.el
@@ -177,10 +177,10 @@ If GLYPHS is nil, only the latter behaviour is displayed."
      ("i\\([gdr]\\)" 1 'uiua-monadic-modifier )
      ("\\([gdr]\\)i" 1 'uiua-monadic-modifier )
      (,(rx
-       (seq
-	(opt (any "`¯"))
-	(one-or-more (any "0-9"))
-	(opt (group "." (one-or-more (any "0-9"))))))
+        (seq
+	 (opt (any "`¯"))
+	 (one-or-more (any "0-9"))
+	 (opt (group "." (one-or-more (any "0-9"))))))
       . 'uiua-number)
      (,(uiua--generate-font-lock-matcher
 	uiua--monadic-function-glyphs
@@ -240,11 +240,11 @@ If GLYPHS is nil, only the latter behaviour is displayed."
 	'("comp" . "lex"))
       . 'uiua-dyadic-function)
      (,(concat
-       "\\(^\\|[^&a-zA-Z]\\)\\("
-       (uiua--generate-font-lock-matcher
-	uiua--noadic-glyphs
-	(regexp-opt '("pi" "i" "e")))
-       "\\)\\([^&a-zA-Z]\\|$\\)")
+        "\\(^\\|[^&a-zA-Z]\\)\\("
+        (uiua--generate-font-lock-matcher
+	 uiua--noadic-glyphs
+	 (regexp-opt '("pi" "i" "e")))
+        "\\)\\([^&a-zA-Z]\\|$\\)")
       2 'uiua-noadic-or-constant)
      (,(uiua--generate-font-lock-matcher
 	uiua--dyadic-modifier-glyphs
@@ -261,7 +261,7 @@ If GLYPHS is nil, only the latter behaviour is displayed."
     ;; so that they are parsed separately
     (dolist (i uiua--primitives)
       (dolist (j i)
-      (modify-syntax-entry j "." table)))
+        (modify-syntax-entry j "." table)))
     (modify-syntax-entry ?# "<" table)
     (modify-syntax-entry ?\n ">" table)
     (modify-syntax-entry ?@ "_" table)

--- a/uiua-mode.el
+++ b/uiua-mode.el
@@ -22,50 +22,41 @@
 
 (defcustom uiua-mode-hook nil
   "The hook that is called after loading `uiua-mode'."
-  :type 'hook
-  :group 'uiua)
+  :type 'hook)
 
 (defcustom uiua-command
   "uiua"
   "Default command to use Uiua."
-  :group 'uiua-mode
   :version "27.1"
   :type 'string)
 
 (defface uiua-number
   '((t (:inherit font-lock-function-name-face)))
-  "Face used for numbers in Uiua."
-  :group 'uiua)
+  "Face used for numbers in Uiua.")
 
 (defface uiua-noadic-or-constant
   '((t (:inherit font-lock-preprocessor-face)))
-  "Face used for noadic functions and builtin contants."
-  :group 'uiua)
+  "Face used for noadic functions and builtin contants.")
 
 (defface uiua-monadic-function
   '((t (:inherit font-lock-builtin-face)))
-  "Face used for Uiua in-built monadic functions."
-  :group 'uiua)
+  "Face used for Uiua in-built monadic functions.")
 
 (defface uiua-dyadic-function
   '((t (:inherit font-lock-variable-name-face)))
-  "Face used for Uiua in-built dyadic functions."
-  :group 'uiua)
+  "Face used for Uiua in-built dyadic functions.")
 
 (defface uiua-ocean-function
   '((t (:inherit font-lock-keyword-face)))
-  "Face used for Uiua ocean functions."
-  :group 'uiua)
+  "Face used for Uiua ocean functions.")
 
 (defface uiua-monadic-modifier
   '((t (:inherit font-lock-type-face)))
-  "Face used for Uiua in-built monadic modifiers."
-  :group 'uiua)
+  "Face used for Uiua in-built monadic modifiers.")
 
 (defface uiua-dyadic-modifier
   '((t (:inherit font-lock-constant-face)))
-  "Face used for Uiua in-built dyadic modifiers."
-  :group 'uiua)
+  "Face used for Uiua in-built dyadic modifiers.")
 
 (defvar uiua--*last-compiled-file* nil
   "Last compiled output of `uiua-standalone-compile'.")
@@ -354,7 +345,6 @@ output.  If CMD fails the buffer remains unchanged."
 (define-derived-mode uiua-base-mode prog-mode "Uiua"
   "Generic Major mode for editing Uiua files."
   :syntax-table uiua--syntax-table
-  :group 'uiua
   (add-hook
    'before-save-hook
    'uiua-format-buffer nil t)
@@ -364,7 +354,6 @@ output.  If CMD fails the buffer remains unchanged."
 ;;;###autoload
 (define-derived-mode uiua-mode uiua-base-mode "Uiua"
   "Major mode for editing Uiua files."
-  :group 'uiua
   (add-to-list 'hs-special-modes-alist '(uiua-mode "{\\|" "}\\|]" "#"))
   (setq-local font-lock-defaults uiua--font-lock-defaults))
 

--- a/uiua-ts-mode.el
+++ b/uiua-ts-mode.el
@@ -13,7 +13,7 @@
 (require 'treesit)
 
 (defgroup uiua-ts nil
-  "Settings for ts-powered Uiua"
+  "Settings for ts-powered Uiua."
   :prefix "uiua-ts-"
   :prefix "uiua-"
   :group 'uiua)

--- a/uiua-ts-mode.el
+++ b/uiua-ts-mode.el
@@ -63,11 +63,11 @@
    :feature 'ocean-function
    :override t
    '((function [ "⋄" "~" "≊" "≃" "∸"
-       "ab" "abyss"
-       "de" "deep"
-       "ro" "rock"
-       "se" "seabed"
-       "surface"])
+                 "ab" "abyss"
+                 "de" "deep"
+                 "ro" "rock"
+                 "se" "seabed"
+                 "surface"])
      @uiua-ocean-function)
 
    :language 'uiua

--- a/uiua-ts-mode.el
+++ b/uiua-ts-mode.el
@@ -18,7 +18,7 @@
   :prefix "uiua-"
   :group 'uiua)
 
-(defvar uiua--ts-indent-rules
+(defvar uiua-ts--indent-rules
   `((uiua
      ((parent-is "program") parent-bol 0)
      ((query ((array (closeCurly)@curly :?
@@ -30,7 +30,7 @@
       ((parent-is "inlineFunction") parent 2)
       ((parent-is "array") parent 2)))))
 
-(defvar uiua--ts-font-lock-rules
+(defvar uiua-ts--font-lock-rules
   (treesit-font-lock-rules
    :language 'uiua
    :feature 'string
@@ -80,12 +80,12 @@
    :feature 'comment
    '((comment) @font-lock-comment-face)))
 
-(defun uiua--ts-setup ()
+(defun uiua-ts--setup ()
   "Setup for uiua treesitter mode."
   (setq-local treesit-font-lock-settings
-	      uiua--ts-font-lock-rules)
+	      uiua-ts--font-lock-rules)
   (setq-local treesit-simple-indent-rules
-	      uiua--ts-indent-rules)
+	      uiua-ts--indent-rules)
   (setq-local treesit-font-lock-feature-list
 	      '((comment default string)
 		(number)
@@ -105,7 +105,7 @@ Uses tree-sitter."
   (setq-local font-lock-defaults nil) ; to let ts do the hard work
   (when (treesit-ready-p 'uiua)
     (treesit-parser-create 'uiua)
-    (uiua--ts-setup)))
+    (uiua-ts--setup)))
 
 (provide 'uiua-ts-mode)
 

--- a/uiua-ts-mode.el
+++ b/uiua-ts-mode.el
@@ -18,10 +18,6 @@
   :prefix "uiua-"
   :group 'uiua)
 
-(defcustom uiua-ts-mode-hook nil
-  "The hook that is called after starting uiua-ts-mode."
-  :type 'hook)
-
 (defvar uiua--ts-indent-rules
   `((uiua
      ((parent-is "program") parent-bol 0)

--- a/uiua-ts-mode.el
+++ b/uiua-ts-mode.el
@@ -3,6 +3,7 @@
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; URL: https://github.com/crmsnbleyd/uiua-mode
 ;; Keywords: languages, uiua
+;; Package-Requires: ((emacs "29.1") (uiua-mode "0.1"))
 
 ;;; Commentary:
 ;; A major mode for Uiua that uses treesitter for parsing

--- a/uiua-ts-mode.el
+++ b/uiua-ts-mode.el
@@ -26,9 +26,9 @@
       parent 0)
      ((query ((inlineFunction
 	       (closeParen)@paren :?))
-      parent 0)
-     ((parent-is "inlineFunction") parent 2)
-     ((parent-is "array") parent 2))))
+             parent 0)
+      ((parent-is "inlineFunction") parent 2)
+      ((parent-is "array") parent 2)))))
 
 (defvar uiua--ts-font-lock-rules
   (treesit-font-lock-rules


### PR DESCRIPTION
Hey, here are some changes with a view to pushing this towards inclusion in MELPA. Couple of notes along the way:

- I'd suggest dropping the `uiua-base-mode`, in favour of just making `uiua-mode` the parent mode of `uiua-ts-mode`. Other modes seem to do this without issues.
- I switched the code to use reformatter, which saves a ton of code, but makes the error reporting a little quieter: this could be tweaked if necessary.
- The non-TS mode font lock is wrong for the built-in function `parse`, in that I guess the first `par` is assumed to `partition`. I didn't see a list of built-in functions to update, but that might be the way to go.
- `inferior-uiua` appears to be a work in progress so I didn't touch that — it could be omitted from an initial version of the package. Best would be to leave the file out of the repo until it has useful contents. :)